### PR TITLE
v1.4.0 python3.66 with FMA, AVX, AVX2, SSE4.1, SSE4.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ pip install --ignore-installed --upgrade "Download URL"
 | 1.2.0rc1 | CPU | Arch Linux   | 6.3            | 3.6.1       | Optimized for Intel Core i7-4500U         | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.2.0rc1-cp36-cp36m-linux_x86_64.whl)     |
 | 1.2.0rc2 | CPU | Arch Linux   | 7.1            | 3.6.1       | Optimized for Intel Core i7-4500U + MKL   | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.2.0rc2-cp36-cp36m-linux_x86_64.whl)     |
 | 1.4.0    | CPU | Ubuntu 16.04 | 5.4            | 3.5.2       | FMA, AVX, AVX2, SSE4.1, SSE4.2            | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.4.0-cp35-cp35m-linux_x86_64.whl)        |
+| 1.4.0    | CPU | Ubuntu 16.04 | 5.4            | 3.6.3       | FMA, AVX, AVX2, SSE4.1, SSE4.2            | [Download](https://github.com/sigilioso/tensorflow-build/raw/master/tensorflow-1.4.0-cp36-cp36m-linux_x86_64.whl)       |
 | 1.4.0    | CPU | Ubuntu 16.04 | 5.4            | 2.7.12      | FMA, AVX, AVX2, SSE4.1, SSE4.2            | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.4.0-cp27-cp27mu-linux_x86_64.whl)       |
 | 1.4.0rc1 | CPU | Ubuntu 16.10 | 6.2            | 3.6.0b2     | SSE4.1, SSE4.2, AVX                       | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.4.0rc1-cp36-cp36m-linux_x86_64.whl)     |
 | 1.2.1    | CPU | macOS Sierra | clang-802.0.42 | 2.7.13      | AVX, SSE4.1, SSE4.2                       | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.2.1-cp27-cp27m-macosx_10_12_x86_64.whl) |
@@ -22,6 +23,7 @@ pip install --ignore-installed --upgrade "Download URL"
 | 1.2.1    | CPU | macOS Sierra | clang-802.0.42 | 3.6.1       | AVX, SSE4.1, SSE4.2                       | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.2.1-cp36-cp36m-macosx_10_12_x86_64.whl) |
 | 1.2.1    | CPU | macOS Sierra | clang-802.0.42 | 3.6.1       | FMA, AVX, AVX2, SSE4.1, SSE4.2            | [Download](https://github.com/lakshayg/tensorflow-build/raw/72454268db8ce69e0fe3c7b23c17aad6ea69b257/tensorflow-1.2.1-cp36-cp36m-macosx_10_12_x86_64.whl) |
 | 1.4.0    | CPU | macOS Sierra | clang-802.0.42 | 3.6.3       | SSE4.1, SSE4.2, AVX, AVX2, FMA            | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.4.0-cp36-cp36m-macosx_10_12_x86_64.whl) |
+
 
 **External Links** (Please consider giving a :star: or :+1: to the original sources in case you use external links)
 


### PR DESCRIPTION
v1.4.0 python3.66 with FMA, AVX, AVX2, SSE4.1, SSE4.2 in ubuntu 16.04