### PR TITLE
Added tensorflow 1.5.0 for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ pip install --ignore-installed --upgrade "Download URL"
 | 1.4.1    | CPU | macOS High Sierra | clang-900.0.38 | 3.6.2      | SSE4.1, SSE4.2, AVX, AVX2, FMA            | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.4.1-cp36-cp36m-macosx_10_13_x86_64.whl) |
 | 1.4.1    | CPU | macOS Sierra | clang-900.0.39.2   | 2.7.13    | AVX, SSE4.1, SSE4.2                       | [Download](https://github.com/lakshayg/tensorflow-build/releases/download/v1.4.1-macosx_10_12-py27-py36-avx-sse41-sse42/tensorflow-1.4.1-cp27-cp27m-macosx_10_12_intel.whl) |
 | 1.4.1    | CPU | macOS Sierra | clang-900.0.39.2   | 3.6.1       | AVX, SSE4.1, SSE4.2                       | [Download](https://github.com/lakshayg/tensorflow-build/releases/download/v1.4.1-macosx_10_12-py27-py36-avx-sse41-sse42/tensorflow-1.4.1-cp36-cp36m-macosx_10_12_x86_64.whl) |
-| 1.5.0    | CPU | macOS High Sierra | clang-900.0.39.2   | 3.6.4       | SSE4.2, AVX, AVX2, FMA                        | [Download](https://github.com/lakshayg/tensorflow-build/raw/tf1.5/tensorflow-1.5.0-cp36-cp36m-macosx_10_13_x86_64.whl) |
+| 1.5.0    | CPU | macOS High Sierra | clang-900.0.39.2   | 3.6.4       | SSE4.2, AVX, AVX2, FMA                        | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.5.0-cp36-cp36m-macosx_10_13_x86_64.whl) |
 
 **External Links** (Please consider giving a :star: or :+1: to the original sources in case you use external links)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ pip install --ignore-installed --upgrade "Download URL"
 | 1.4.1    | CPU | macOS High Sierra | clang-900.0.38 | 3.6.2      | SSE4.1, SSE4.2, AVX, AVX2, FMA            | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.4.1-cp36-cp36m-macosx_10_13_x86_64.whl) |
 | 1.4.1    | CPU | macOS Sierra | clang-900.0.39.2   | 2.7.13    | AVX, SSE4.1, SSE4.2                       | [Download](https://github.com/lakshayg/tensorflow-build/releases/download/v1.4.1-macosx_10_12-py27-py36-avx-sse41-sse42/tensorflow-1.4.1-cp27-cp27m-macosx_10_12_intel.whl) |
 | 1.4.1    | CPU | macOS Sierra | clang-900.0.39.2   | 3.6.1       | AVX, SSE4.1, SSE4.2                       | [Download](https://github.com/lakshayg/tensorflow-build/releases/download/v1.4.1-macosx_10_12-py27-py36-avx-sse41-sse42/tensorflow-1.4.1-cp36-cp36m-macosx_10_12_x86_64.whl) |
+| 1.5.0    | CPU | macOS High Sierra | clang-900.0.39.2   | 3.6.4       | SSE4.2, AVX, AVX2, FMA                        | [Download](https://github.com/lakshayg/tensorflow-build/raw/tf1.5/tensorflow-1.5.0-cp36-cp36m-macosx_10_13_x86_64.whl) |
 
 **External Links** (Please consider giving a :star: or :+1: to the original sources in case you use external links)
 


### PR DESCRIPTION
Built on macOS High Sierra with clang-900.0.39.2, Python 3.6.4 with support for SSE4.2, AVX, AVX2, FMA
Build command:
bazel build -c opt --copt=-mavx --copt=-mavx2 --copt=-mfma --copt=-msse4.2 -k //tensorflow/tools/pip_package:build_pip_package