### PR TITLE
Add TF 1.8.0 for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ pip install --ignore-installed --upgrade "Download URL"
 | 1.5.0    | CPU | macOS High Sierra | clang-900.0.39.2   | 3.6.4       | SSE4.2, AVX, AVX2, FMA                        | [Download](https://github.com/lakshayg/tensorflow-build/raw/53f39575cdd0912e561a67f0afe844ff4b8ef655/tensorflow-1.5.0-cp36-cp36m-macosx_10_13_x86_64.whl) |
 | 1.5.0    | CPU | macOS High Sierra | clang-900.0.39.2   | 3.6.4       | AVX, SSE4.1, SSE4.2                        | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.5.0-cp36-cp36m-macosx_10_13_x86_64.whl) |
 | 1.6.0    | CPU | Ubuntu 16.04      | 5.4                | 2.7.12      | SSE4.1, SSE4.2, AVX, AVX2, FMA             | [Download](https://github.com/lakshayg/tensorflow-build/releases/download/v1.6.0-ubuntu_16_04-py27-avx-avx2-fma-sse41-sse42/tensorflow-1.6.0-cp27-cp27mu-linux_x86_64.whl) |
-
+| 1.8.0    | CPU | macOS High Sierra      | clang-902.0.39.1  | 3.6.5      | SSE4.1, SSE4.2, AVX, AVX2, FMA, SSSE3, POPCNT, CX16  | [Download](https://github.com/lakshayg/tensorflow-build/raw/master/tensorflow-1.8.0-cp36-cp36m-macosx_10_7_x86_64.whl) |
 **External Links** (Please consider giving a :star: or :+1: to the original sources in case you use external links)
 
 | TF       | HW       | OS           | Python        | Supports                            |                                         |


### PR DESCRIPTION
Build command:

bazel build --config opt --copt=-march=native --copt=-mssse3 --copt=-mfma --copt=-mcx16 --copt=-msse4.1 --copt=-msse4.2 --copt=-mpopcnt --copt=-mavx --copt=-mavx2 -k //tensorflow/tools/pip_package:build_pip_package

Hope it is useful for others.
Thanks for collecting.