### PR TITLE
Added release for TF2.0 on Windows with 3.0 compute capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ pip install --ignore-installed --upgrade "Download URL" --user
 | 1.0-1.11 | CPU, GPU | Windows      | 2.7, 3.5, 3.6 | AVX, AVX2                           | [Link](https://github.com/fo40225/tensorflow-windows-wheel) |
 | 1.12.0| CPU | MacOS Mojave      | 3.6.0 | FMA, AVX, AVX2, SSE4.1, SSE4.2  | [Link](https://github.com/yaroslavvb/tensorflow-community-wheels/issues/95) |
 | 1.13.1| CPU | MacOS Mojave      | 3.6.5 | FMA, AVX, AVX2, SSE4.1, SSE4.2  | [Link](https://github.com/xiaobailong24/tensorflow-build/releases/download/tf1.13.1-macOS-mojave-py3/tensorflow-1.13.1-cp36-cp36m-macosx_10_13_x86_64.whl) |
+| 2.0.0| CPU, GPU | Windows      | 3.6.7 | FMA, AVX, AVX2, SSE4.1, SSE4.2  | [Link](https://github.com/coffeenmusic/tensorflow-build/releases/download/tf2.0rc0-windows-py3/tensorflow-2.0.0rc0-cp36-cp36m-win_amd64.whl) |
 
 **Visit [tensorflow.org][1] for instructions on building tensorflow for your machine.**
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ pip install --ignore-installed --upgrade "Download URL" --user
 | 1.0-1.11 | CPU, GPU | Windows      | 2.7, 3.5, 3.6 | AVX, AVX2                           | [Link](https://github.com/fo40225/tensorflow-windows-wheel) |
 | 1.12.0| CPU | MacOS Mojave      | 3.6.0 | FMA, AVX, AVX2, SSE4.1, SSE4.2  | [Link](https://github.com/yaroslavvb/tensorflow-community-wheels/issues/95) |
 | 1.13.1| CPU | MacOS Mojave      | 3.6.5 | FMA, AVX, AVX2, SSE4.1, SSE4.2  | [Link](https://github.com/xiaobailong24/tensorflow-build/releases/download/tf1.13.1-macOS-mojave-py3/tensorflow-1.13.1-cp36-cp36m-macosx_10_13_x86_64.whl) |
-| 2.0.0| CPU, GPU | Windows      | 3.6.7 | FMA, AVX, AVX2, SSE4.1, SSE4.2  | [Link](https://github.com/coffeenmusic/tensorflow-build/releases/download/tf2.0rc0-windows-py3/tensorflow-2.0.0rc0-cp36-cp36m-win_amd64.whl) |
+| 2.0.0| CPU, GPU | Windows      | 3.6.7 | AVX, AVX2, Compute Capability 3.0  | [Link](https://github.com/coffeenmusic/tensorflow-build/releases/download/tf2.0rc0-windows-py3/tensorflow-2.0.0rc0-cp36-cp36m-win_amd64.whl) |
 
 **Visit [tensorflow.org][1] for instructions on building tensorflow for your machine.**
 


### PR DESCRIPTION
This is my first pull request, so if I messed anything up please let me know. I created a release on my fork for the TF2.0 .whl and then linked to it in the README.md.